### PR TITLE
Add weekly schedule to test and E2E workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    # Run every Monday at 8:00 UTC to verify E2E tests remain valid over time
+    - cron: '0 8 * * 1'
 
 jobs:
   e2e:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Run every Monday at 8:00 UTC to verify tests remain valid over time
+    - cron: '0 8 * * 1'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Add weekly cron schedule to `test.yml` and `e2e.yml` workflows
- Tests run every Monday at 8:00 UTC to verify they remain valid over time
- Existing triggers (push to main, pull_request) are preserved

## Test plan
- [ ] Verify workflow syntax is valid (actionlint passed locally)
- [ ] Wait for scheduled run on Monday to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)