### PR TITLE
PVC support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -282,7 +282,7 @@ resource "kubernetes_deployment_v1" "this" {
           }
         }
 
-        # Volumes from secrets/configmaps
+        # Volumes from secrets/configmaps/PVCs
         dynamic "volume" {
           for_each = var.volumes
           content {
@@ -301,6 +301,14 @@ resource "kubernetes_deployment_v1" "this" {
               content {
                 name         = config_map.value
                 default_mode = volume.value.mode
+              }
+            }
+
+            dynamic "persistent_volume_claim" {
+              for_each = volume.value.persistent_volume_claim != null ? [volume.value.persistent_volume_claim] : []
+              content {
+                claim_name = persistent_volume_claim.value
+                read_only  = volume.value.read_only
               }
             }
           }

--- a/tests/volumes.tftest.hcl
+++ b/tests/volumes.tftest.hcl
@@ -110,3 +110,50 @@ run "subpath_mount" {
     error_message = "SubPath should be settings.yaml"
   }
 }
+
+# Test: PersistentVolumeClaim volume
+run "pvc_volume" {
+  command = plan
+
+  variables {
+    volumes = [{
+      name                    = "data"
+      mount_path              = "/data"
+      persistent_volume_claim = "app-data-pvc"
+    }]
+  }
+
+  assert {
+    condition     = length(kubernetes_deployment_v1.this.spec[0].template[0].spec[0].volume) == 1
+    error_message = "One volume should be configured"
+  }
+
+  assert {
+    condition     = kubernetes_deployment_v1.this.spec[0].template[0].spec[0].volume[0].persistent_volume_claim[0].claim_name == "app-data-pvc"
+    error_message = "PVC claim name should be app-data-pvc"
+  }
+
+  assert {
+    condition     = kubernetes_deployment_v1.this.spec[0].template[0].spec[0].container[0].volume_mount[0].mount_path == "/data"
+    error_message = "Volume mount path should be /data"
+  }
+}
+
+# Test: PersistentVolumeClaim volume with read_only
+run "pvc_volume_readonly" {
+  command = plan
+
+  variables {
+    volumes = [{
+      name                    = "data"
+      mount_path              = "/data"
+      persistent_volume_claim = "app-data-pvc"
+      read_only               = true
+    }]
+  }
+
+  assert {
+    condition     = kubernetes_deployment_v1.this.spec[0].template[0].spec[0].volume[0].persistent_volume_claim[0].read_only == true
+    error_message = "PVC should be mounted read-only"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -229,13 +229,14 @@ variable "env_value_from" {
 variable "volumes" {
   description = "Volume definitions with mount configurations"
   type = list(object({
-    name       = string
-    mount_path = string
-    sub_path   = optional(string)
-    read_only  = optional(bool, false)
-    secret     = optional(string)
-    config_map = optional(string)
-    mode       = optional(string)
+    name                    = string
+    mount_path              = string
+    sub_path                = optional(string)
+    read_only               = optional(bool, false)
+    secret                  = optional(string)
+    config_map              = optional(string)
+    persistent_volume_claim = optional(string)
+    mode                    = optional(string)
   }))
   default = []
 }


### PR DESCRIPTION
This pull request adds support for mounting PersistentVolumeClaims (PVCs) in Kubernetes deployments managed by Terraform. The changes extend the existing volume configuration to allow referencing PVCs, and include new tests to verify correct behavior.

**Kubernetes Deployment Enhancements:**

* Updated the comment in the `main.tf` deployment resource to reflect support for volumes from secrets, configmaps, and PVCs.
* Added logic to the `main.tf` deployment resource to dynamically configure `persistent_volume_claim` blocks for volumes that specify a PVC, including support for the `read_only` attribute.

**Configuration and Testing:**

* Extended the `volumes` variable definition in `variables.tf` to include an optional `persistent_volume_claim` field.
* Added two new test cases in `tests/volumes.tftest.hcl` to verify PVC volume mounting and read-only behavior.