### PR TITLE
Add full nginx canary annotations support

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -161,14 +161,23 @@ variable "ingress_acme_enabled" {
 # =============================================================================
 
 variable "canary" {
-  description = "Canary deployment configuration for nginx ingress controller"
+  description = "Canary deployment configuration for nginx ingress controller. Supports all nginx canary annotations."
   type = object({
-    enabled = bool
-    weight  = optional(number, 0)
+    enabled        = bool
+    weight         = optional(number, 0)
+    weight_total   = optional(number)
+    header         = optional(string, "canary")
+    header_value   = optional(string)
+    header_pattern = optional(string)
+    cookie         = optional(string, "canary")
   })
   default = {
     enabled = false
-    weight  = 0
+  }
+
+  validation {
+    condition     = !(var.canary.header_value != null && var.canary.header_pattern != null)
+    error_message = "Cannot specify both header_value and header_pattern. Use one or the other."
   }
 }
 


### PR DESCRIPTION
## Summary

- Expand the `canary` variable to support all nginx-ingress canary annotations
- Add `header`, `header_value`, `header_pattern`, `cookie`, and `weight_total` options
- Default behavior: when `canary.enabled=true`, adds both `canary-by-header: canary` and `canary-by-cookie: canary`
- Add validation to prevent using both `header_value` and `header_pattern` simultaneously

## Usage Examples

```hcl
# Default: header + cookie both set to "canary"
canary = { enabled = true }

# Weight-based only (20% traffic)
canary = { enabled = true, weight = 20, header = null, cookie = null }

# Header with specific value
canary = { enabled = true, header = "x-canary", header_value = "prod-v2", cookie = null }
```

## Test plan

- [ ] Verify `terraform validate` passes
- [ ] Test with `canary = { enabled = true }` - should add header and cookie annotations
- [ ] Test with `canary = { enabled = true, header = null }` - should only add cookie
- [ ] Test with weight-based routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)